### PR TITLE
Update dependency to fix 8.0.0 crash

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
         transitive = true;
     }
-    compile 'io.paperdb:paperdb:2.0'
+    compile 'io.paperdb:paperdb:2.6'
     compile 'com.android.support:appcompat-v7:25.2.0'
     compile 'com.android.support:cardview-v7:25.2.0'
     compile 'com.android.support:design:25.2.0'


### PR DESCRIPTION
On recent versions of Android the app crashes frequently, particularly when selecting a stop. A dependency introduced via Paper v2.0 makes a call (ObjectStreamClass.getConstructorId()) that is not supported on SDK 25+.